### PR TITLE
Add VM and LXC creation wizards with test suite

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
   "scripts": {
     "start": "bun run src/index.tsx",
     "dev": "bun --watch run src/index.tsx",
+    "test": "bun test",
+    "test:watch": "bun test --watch",
+    "test:coverage": "bun test --coverage",
     "build": "bun build ./src/index.tsx --compile --minify --outfile dist/proxmux",
     "build:darwin-arm64": "bun build ./src/index.tsx --compile --minify --target=bun-darwin-arm64 --outfile dist/proxmux-darwin-arm64",
     "build:darwin-x64": "bun build ./src/index.tsx --compile --minify --target=bun-darwin-x64 --outfile dist/proxmux-darwin-x64",
@@ -50,6 +53,7 @@
   "devDependencies": {
     "@types/bun": "latest",
     "@types/react": "^18.3.12",
+    "ink-testing-library": "^4.0.0",
     "react-devtools-core": "^7.0.1",
     "typescript": "^5.7.2"
   }

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -164,3 +164,123 @@ export interface NetworkInterface {
   "inet"?: string;
   "inet6"?: string;
 }
+
+// Storage content item (ISO, templates, etc.)
+export interface StorageContent {
+  volid: string;
+  content: string;
+  format: string;
+  size: number;
+  ctime?: number;
+  filename?: string;
+}
+
+// Template types for LXC creation
+export interface Template {
+  volid: string;
+  format: string;
+  size: number;
+  content: string;
+}
+
+export interface AvailableTemplate {
+  template: string;
+  type: string;
+  package: string;
+  version: string;
+  os: string;
+  section: string;
+  headline: string;
+  description?: string;
+  maintainer?: string;
+  location?: string;
+  md5sum?: string;
+  sha512sum?: string;
+  infopage?: string;
+}
+
+// LXC creation configuration
+export interface LXCCreateConfig {
+  vmid: number;
+  hostname: string;
+  ostemplate: string;
+  password?: string;
+  "ssh-public-keys"?: string;
+  cores?: number;
+  memory?: number;
+  swap?: number;
+  rootfs: string; // format: "storage:size" e.g., "local-lvm:8"
+  net0?: string; // format: "name=eth0,bridge=vmbr0,ip=dhcp" or with static IP
+  nameserver?: string;
+  searchdomain?: string;
+  unprivileged?: boolean;
+  start?: boolean;
+  features?: string; // e.g., "nesting=1"
+  onboot?: boolean;
+}
+
+// Network configuration for the LXC wizard
+export interface LXCNetworkConfig {
+  bridge: string;
+  ipType: "dhcp" | "static";
+  ip?: string;
+  gateway?: string;
+  ip6Type?: "auto" | "dhcp" | "static" | "none";
+  ip6?: string;
+  gateway6?: string;
+  firewall?: boolean;
+}
+
+// VM Creation types
+export type VMOsType =
+  | "l26"      // Linux 2.6+/3.x/4.x/5.x/6.x kernel
+  | "l24"      // Linux 2.4 kernel
+  | "win11"    // Windows 11
+  | "win10"    // Windows 10
+  | "win8"     // Windows 8.x
+  | "win7"     // Windows 7
+  | "wvista"   // Windows Vista
+  | "wxp"      // Windows XP
+  | "w2k"      // Windows 2000
+  | "w2k8"     // Windows 2008
+  | "w2k3"     // Windows 2003
+  | "w2k12"    // Windows 2012
+  | "w2k16"    // Windows 2016
+  | "w2k19"    // Windows 2019
+  | "w2k22"    // Windows 2022
+  | "solaris"  // Solaris kernel
+  | "other";   // Other OS
+
+export type VMDiskFormat = "qcow2" | "raw" | "vmdk";
+
+export type VMNetModel = "virtio" | "e1000" | "rtl8139" | "vmxnet3";
+
+export interface VMCreateDisk {
+  storage: string;
+  size: number;  // Size in GB
+  format?: VMDiskFormat;
+}
+
+export interface VMCreateNetwork {
+  bridge: string;
+  model?: VMNetModel;
+  macaddr?: string;
+  firewall?: boolean;
+}
+
+export interface VMCreateConfig {
+  vmid: number;
+  name: string;
+  iso?: string;           // ISO volume ID (e.g., "local:iso/ubuntu.iso")
+  ostype: VMOsType;
+  cores: number;
+  sockets: number;
+  memory: number;         // Memory in MB
+  disk: VMCreateDisk;
+  network: VMCreateNetwork;
+  boot?: string;          // Boot order (e.g., "order=scsi0;ide2;net0")
+  start?: boolean;        // Start after creation
+  cpu?: string;           // CPU type (e.g., "host", "kvm64")
+  bios?: "seabios" | "ovmf";
+  machine?: string;       // Machine type (e.g., "q35")
+}

--- a/src/components/common/HelpOverlay.tsx
+++ b/src/components/common/HelpOverlay.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+import { Box, Text, useInput } from "ink";
+
+interface HelpOverlayProps {
+  onClose: () => void;
+}
+
+export function HelpOverlay({ onClose }: HelpOverlayProps) {
+  useInput((input, key) => {
+    if (key.escape || input === "?" || input === "q" || key.return) {
+      onClose();
+    }
+  });
+
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="double"
+      borderColor="cyan"
+      padding={1}
+      width={60}
+    >
+      <Box marginBottom={1}>
+        <Text bold color="cyan">
+          Proxmux Help
+        </Text>
+      </Box>
+
+      <Box flexDirection="column" marginBottom={1}>
+        <Text bold underline>Navigation</Text>
+        <Text>  <Text color="yellow">1-4</Text>       Switch views (Dashboard, VMs, Containers, Storage)</Text>
+        <Text>  <Text color="yellow">j/k ↑/↓</Text>   Move up/down in lists</Text>
+        <Text>  <Text color="yellow">Enter</Text>     Select item / Open detail view</Text>
+        <Text>  <Text color="yellow">Esc</Text>       Go back / Cancel</Text>
+        <Text>  <Text color="yellow">Tab</Text>       Next field (in forms)</Text>
+      </Box>
+
+      <Box flexDirection="column" marginBottom={1}>
+        <Text bold underline>Actions</Text>
+        <Text>  <Text color="yellow">c</Text>         Create new VM/Container</Text>
+        <Text>  <Text color="yellow">s</Text>         Start VM/Container</Text>
+        <Text>  <Text color="yellow">x</Text>         Stop VM/Container</Text>
+        <Text>  <Text color="yellow">R</Text>         Reboot VM/Container</Text>
+        <Text>  <Text color="yellow">r</Text>         Refresh current view</Text>
+      </Box>
+
+      <Box flexDirection="column" marginBottom={1}>
+        <Text bold underline>General</Text>
+        <Text>  <Text color="yellow">?</Text>         Show this help</Text>
+        <Text>  <Text color="yellow">q</Text>         Quit proxmux</Text>
+        <Text>  <Text color="yellow">Ctrl+C</Text>    Quit proxmux</Text>
+      </Box>
+
+      <Box flexDirection="column">
+        <Text bold underline>Wizard Navigation</Text>
+        <Text>  <Text color="yellow">Ctrl+N</Text>    Next step</Text>
+        <Text>  <Text color="yellow">Ctrl+P</Text>    Previous step</Text>
+        <Text>  <Text color="yellow">Tab</Text>       Next field</Text>
+        <Text>  <Text color="yellow">Esc</Text>       Cancel / Go back</Text>
+      </Box>
+
+      <Box marginTop={1}>
+        <Text dimColor>Press Esc, ?, or Enter to close</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/src/components/forms/Checkbox.tsx
+++ b/src/components/forms/Checkbox.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { Box, Text, useInput } from "ink";
+
+export interface CheckboxProps {
+  label: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  isActive?: boolean;
+  description?: string;
+}
+
+export function Checkbox({
+  label,
+  checked,
+  onChange,
+  isActive = false,
+  description,
+}: CheckboxProps) {
+  useInput(
+    (input, key) => {
+      if (!isActive) return;
+
+      if (key.return || input === " ") {
+        onChange(!checked);
+      }
+    },
+    { isActive }
+  );
+
+  return (
+    <Box>
+      <Text bold={isActive} color={isActive ? "cyan" : undefined}>
+        {checked ? "☑" : "☐"} {label}
+      </Text>
+      {description && <Text dimColor> - {description}</Text>}
+      {isActive && <Text dimColor> [Space/Enter to toggle]</Text>}
+    </Box>
+  );
+}

--- a/src/components/forms/NumberInput.tsx
+++ b/src/components/forms/NumberInput.tsx
@@ -1,0 +1,113 @@
+import React, { useState, useEffect } from "react";
+import { Box, Text, useInput } from "ink";
+
+export interface NumberInputProps {
+  label: string;
+  value: number | null;
+  onChange: (value: number | null) => void;
+  min?: number;
+  max?: number;
+  step?: number;
+  unit?: string;
+  isActive?: boolean;
+  required?: boolean;
+  placeholder?: string;
+}
+
+export function NumberInput({
+  label,
+  value,
+  onChange,
+  min,
+  max,
+  step = 1,
+  unit,
+  isActive = false,
+  required = false,
+  placeholder = "",
+}: NumberInputProps) {
+  const [inputValue, setInputValue] = useState(value?.toString() ?? "");
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setInputValue(value?.toString() ?? "");
+  }, [value]);
+
+  useEffect(() => {
+    const num = parseFloat(inputValue);
+    if (required && !inputValue.trim()) {
+      setError("This field is required");
+    } else if (inputValue && isNaN(num)) {
+      setError("Must be a number");
+    } else if (min !== undefined && num < min) {
+      setError(`Minimum: ${min}${unit ? ` ${unit}` : ""}`);
+    } else if (max !== undefined && num > max) {
+      setError(`Maximum: ${max}${unit ? ` ${unit}` : ""}`);
+    } else {
+      setError(null);
+    }
+  }, [inputValue, min, max, required, unit]);
+
+  useInput(
+    (input, key) => {
+      if (!isActive) return;
+
+      if (key.backspace || key.delete) {
+        const newValue = inputValue.slice(0, -1);
+        setInputValue(newValue);
+        const num = parseFloat(newValue);
+        onChange(isNaN(num) ? null : num);
+      } else if (key.upArrow) {
+        const current = value ?? (min ?? 0);
+        const newValue = max !== undefined ? Math.min(max, current + step) : current + step;
+        onChange(newValue);
+      } else if (key.downArrow) {
+        const current = value ?? (min ?? 0);
+        const newValue = min !== undefined ? Math.max(min, current - step) : current - step;
+        onChange(newValue);
+      } else if (!key.return && !key.escape && !key.tab && input) {
+        // Only allow numeric input and decimal point
+        if (/^[\d.]$/.test(input)) {
+          const newValue = inputValue + input;
+          setInputValue(newValue);
+          const num = parseFloat(newValue);
+          if (!isNaN(num)) {
+            onChange(num);
+          }
+        }
+      }
+    },
+    { isActive }
+  );
+
+  const displayValue = inputValue || placeholder;
+  const showPlaceholder = !inputValue && placeholder;
+
+  const bracketColor = error ? "red" : isActive ? "cyan" : "gray";
+
+  return (
+    <Box flexDirection="column">
+      <Box>
+        <Text bold={isActive} color={isActive ? "cyan" : undefined}>
+          {label}:{" "}
+        </Text>
+        <Text color={bracketColor}>[</Text>
+        <Text color={showPlaceholder ? "gray" : undefined}>
+          {" "}{isActive ? displayValue + "█" : displayValue}{" "}
+        </Text>
+        <Text color={bracketColor}>]</Text>
+        {unit && <Text dimColor> {unit}</Text>}
+        {isActive && (
+          <Text dimColor> ↑/↓ ±{step}</Text>
+        )}
+      </Box>
+      {error && isActive && (
+        <Box paddingLeft={label.length + 2}>
+          <Text color="red" dimColor>
+            {error}
+          </Text>
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/src/components/forms/Select.tsx
+++ b/src/components/forms/Select.tsx
@@ -1,0 +1,148 @@
+import React from "react";
+import { Box, Text, useInput } from "ink";
+
+export interface SelectOption<T = string> {
+  label: string;
+  value: T;
+  description?: string;
+}
+
+export interface SelectProps<T = string> {
+  label: string;
+  options: SelectOption<T>[];
+  value: T | null;
+  onChange: (value: T) => void;
+  isActive?: boolean;
+  placeholder?: string;
+  onOpenChange?: (isOpen: boolean) => void;
+}
+
+export function Select<T = string>({
+  label,
+  options,
+  value,
+  onChange,
+  isActive = false,
+  placeholder = "Select an option...",
+  onOpenChange,
+}: SelectProps<T>) {
+  const [isOpen, setIsOpenState] = React.useState(false);
+  const [highlightedIndex, setHighlightedIndex] = React.useState(0);
+  const [searchQuery, setSearchQuery] = React.useState("");
+
+  const setIsOpen = React.useCallback((open: boolean) => {
+    setIsOpenState(open);
+    onOpenChange?.(open);
+    if (!open) {
+      setSearchQuery(""); // Clear search when closing
+    }
+  }, [onOpenChange]);
+
+  const selectedOption = options.find((opt) => opt.value === value);
+
+  // Filter options based on search query
+  const filteredOptions = React.useMemo(() => {
+    if (!searchQuery) return options;
+    const query = searchQuery.toLowerCase();
+    return options.filter(
+      (opt) =>
+        opt.label.toLowerCase().includes(query) ||
+        opt.description?.toLowerCase().includes(query)
+    );
+  }, [options, searchQuery]);
+
+  useInput(
+    (input, key) => {
+      if (!isActive) return;
+
+      if (key.return) {
+        if (isOpen) {
+          const selected = filteredOptions[highlightedIndex];
+          if (selected) {
+            onChange(selected.value);
+          }
+          setIsOpen(false);
+        } else {
+          setIsOpen(true);
+          const currentIndex = options.findIndex((opt) => opt.value === value);
+          setHighlightedIndex(currentIndex >= 0 ? currentIndex : 0);
+        }
+      } else if (key.escape) {
+        if (searchQuery) {
+          setSearchQuery(""); // First Esc clears search
+          setHighlightedIndex(0);
+        } else {
+          setIsOpen(false);
+        }
+      } else if (key.backspace || key.delete) {
+        if (isOpen && searchQuery) {
+          setSearchQuery((prev) => prev.slice(0, -1));
+          setHighlightedIndex(0);
+        }
+      } else if (isOpen) {
+        if (key.upArrow) {
+          setHighlightedIndex((prev) => Math.max(0, prev - 1));
+        } else if (key.downArrow) {
+          setHighlightedIndex((prev) => Math.min(filteredOptions.length - 1, prev + 1));
+        } else if (input && !key.ctrl && !key.meta && input.length === 1) {
+          // Type to search - append character to search query
+          setSearchQuery((prev) => prev + input);
+          setHighlightedIndex(0);
+        }
+      }
+    },
+    { isActive }
+  );
+
+  const displayValue = selectedOption?.label || placeholder;
+
+  return (
+    <Box flexDirection="column">
+      <Box>
+        <Text bold={isActive} color={isActive ? "cyan" : undefined}>
+          {label}:{" "}
+        </Text>
+        <Text color={isActive ? "cyan" : "gray"}>[</Text>
+        <Text color={selectedOption ? undefined : "gray"}>
+          {" "}{displayValue}{" "}
+        </Text>
+        <Text color={isActive ? "cyan" : "gray"}>]</Text>
+        {isActive && !isOpen && <Text dimColor> ↵ to open</Text>}
+      </Box>
+
+      {isOpen && isActive && (
+        <Box flexDirection="column" paddingLeft={label.length + 2}>
+          {/* Search indicator */}
+          <Box height={1} marginBottom={filteredOptions.length > 0 ? 0 : 0}>
+            <Text color="yellow">
+              {searchQuery ? `🔍 "${searchQuery}"` : "Type to search..."}
+            </Text>
+            <Text dimColor> ({filteredOptions.length} matches)</Text>
+          </Box>
+          {filteredOptions.length === 0 ? (
+            <Box height={1}>
+              <Text color="gray">No matches found</Text>
+            </Box>
+          ) : (
+            filteredOptions.slice(0, 15).map((option, index) => (
+              <Box key={String(option.value)} height={1}>
+                <Text inverse={index === highlightedIndex}>
+                  {option.value === value ? "● " : "○ "}
+                  {option.label}
+                </Text>
+                {option.description && (
+                  <Text dimColor> - {option.description}</Text>
+                )}
+              </Box>
+            ))
+          )}
+          {filteredOptions.length > 15 && (
+            <Box height={1}>
+              <Text dimColor>... and {filteredOptions.length - 15} more (type to filter)</Text>
+            </Box>
+          )}
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/src/components/forms/TextInput.tsx
+++ b/src/components/forms/TextInput.tsx
@@ -1,0 +1,109 @@
+import React, { useState, useEffect } from "react";
+import { Box, Text, useInput } from "ink";
+
+export interface TextInputProps {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  isActive?: boolean;
+  validator?: (value: string) => string | null; // Returns error message or null
+  required?: boolean;
+  password?: boolean;
+  width?: number;
+}
+
+export function TextInput({
+  label,
+  value,
+  onChange,
+  placeholder = "",
+  isActive = false,
+  validator,
+  required = false,
+  password = false,
+  width = 30,
+}: TextInputProps) {
+  const [cursorPosition, setCursorPosition] = useState(value.length);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setCursorPosition(value.length);
+  }, [value.length]);
+
+  useEffect(() => {
+    if (validator) {
+      setError(validator(value));
+    } else if (required && !value.trim()) {
+      setError("This field is required");
+    } else {
+      setError(null);
+    }
+  }, [value, validator, required]);
+
+  useInput(
+    (input, key) => {
+      if (!isActive) return;
+
+      if (key.backspace || key.delete) {
+        if (cursorPosition > 0) {
+          const newValue = value.slice(0, cursorPosition - 1) + value.slice(cursorPosition);
+          onChange(newValue);
+          setCursorPosition(cursorPosition - 1);
+        }
+      } else if (key.leftArrow) {
+        setCursorPosition(Math.max(0, cursorPosition - 1));
+      } else if (key.rightArrow) {
+        setCursorPosition(Math.min(value.length, cursorPosition + 1));
+      } else if (!key.return && !key.escape && !key.tab && !key.upArrow && !key.downArrow && input) {
+        const newValue = value.slice(0, cursorPosition) + input + value.slice(cursorPosition);
+        onChange(newValue);
+        setCursorPosition(cursorPosition + input.length);
+      }
+    },
+    { isActive }
+  );
+
+  const displayValue = password ? "•".repeat(value.length) : value;
+  const showPlaceholder = !value && placeholder;
+
+  // Build the display with cursor
+  let displayText = "";
+  if (showPlaceholder) {
+    displayText = placeholder;
+  } else if (isActive) {
+    displayText =
+      displayValue.slice(0, cursorPosition) +
+      "█" +
+      displayValue.slice(cursorPosition);
+  } else {
+    displayText = displayValue || " ";
+  }
+
+  const bracketColor = error ? "red" : isActive ? "cyan" : "gray";
+
+  return (
+    <Box flexDirection="column">
+      <Box>
+        <Text bold={isActive} color={isActive ? "cyan" : undefined}>
+          {label}:{" "}
+        </Text>
+        <Text color={bracketColor}>[</Text>
+        <Text
+          color={showPlaceholder ? "gray" : undefined}
+          dimColor={!isActive && !showPlaceholder}
+        >
+          {" "}{displayText.slice(0, width - 4)}{" "}
+        </Text>
+        <Text color={bracketColor}>]</Text>
+      </Box>
+      {error && isActive && (
+        <Box paddingLeft={label.length + 2}>
+          <Text color="red" dimColor>
+            {error}
+          </Text>
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/src/components/forms/index.ts
+++ b/src/components/forms/index.ts
@@ -1,0 +1,4 @@
+export { TextInput, type TextInputProps } from "./TextInput.tsx";
+export { Select, type SelectProps, type SelectOption } from "./Select.tsx";
+export { NumberInput, type NumberInputProps } from "./NumberInput.tsx";
+export { Checkbox, type CheckboxProps } from "./Checkbox.tsx";

--- a/src/components/wizard/Wizard.tsx
+++ b/src/components/wizard/Wizard.tsx
@@ -1,0 +1,184 @@
+import React, { useState, useCallback } from "react";
+import { Box, Text, useInput } from "ink";
+
+export interface WizardStep {
+  id: string;
+  title: string;
+  component: React.ComponentType<WizardStepProps>;
+  validate?: () => boolean | string; // Return true if valid, or error message
+}
+
+export interface WizardStepProps {
+  isActive: boolean;
+  onFieldChange: (field: string, value: unknown) => void;
+  data: Record<string, unknown>;
+  setFieldFocus: (index: number) => void;
+  focusedField: number;
+}
+
+export interface WizardProps {
+  title: string;
+  steps: WizardStep[];
+  onComplete: (data: Record<string, unknown>) => Promise<void>;
+  onCancel: () => void;
+  initialData?: Record<string, unknown>;
+}
+
+export function Wizard({
+  title,
+  steps,
+  onComplete,
+  onCancel,
+  initialData = {},
+}: WizardProps) {
+  const [currentStep, setCurrentStep] = useState(0);
+  const [data, setData] = useState<Record<string, unknown>>(initialData);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [focusedField, setFocusedField] = useState(0);
+
+  const step = steps[currentStep];
+  const isFirstStep = currentStep === 0;
+  const isLastStep = currentStep === steps.length - 1;
+
+  const handleFieldChange = useCallback((field: string, value: unknown) => {
+    setData((prev) => ({ ...prev, [field]: value }));
+    setError(null);
+  }, []);
+
+  const goNext = useCallback(async () => {
+    if (!step) return;
+
+    // Validate current step
+    if (step.validate) {
+      const result = step.validate();
+      if (result !== true) {
+        setError(typeof result === "string" ? result : "Please fill in all required fields");
+        return;
+      }
+    }
+
+    if (isLastStep) {
+      setIsSubmitting(true);
+      setError(null);
+      try {
+        await onComplete(data);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "An error occurred");
+        setIsSubmitting(false);
+      }
+    } else {
+      setCurrentStep((prev) => prev + 1);
+      setFocusedField(0);
+      setError(null);
+    }
+  }, [step, isLastStep, data, onComplete]);
+
+  const goPrev = useCallback(() => {
+    if (!isFirstStep) {
+      setCurrentStep((prev) => prev - 1);
+      setFocusedField(0);
+      setError(null);
+    }
+  }, [isFirstStep]);
+
+  useInput(
+    (input, key) => {
+      if (isSubmitting) return;
+
+      if (key.escape) {
+        if (isFirstStep) {
+          onCancel();
+        } else {
+          goPrev();
+        }
+      } else if (key.tab && !key.shift) {
+        // Tab handled by individual step components
+      } else if (input === "n" && key.ctrl) {
+        goNext();
+      } else if (input === "p" && key.ctrl) {
+        goPrev();
+      }
+    },
+    { isActive: !isSubmitting }
+  );
+
+  if (!step) {
+    return <Text color="red">Error: Invalid step</Text>;
+  }
+
+  const StepComponent = step.component;
+
+  return (
+    <Box flexDirection="column" padding={1}>
+      {/* Header */}
+      <Box marginBottom={1}>
+        <Text bold color="blue">
+          {title}
+        </Text>
+      </Box>
+
+      {/* Step indicator */}
+      <Box marginBottom={1}>
+        {steps.map((s, index) => {
+          const isCompleted = index < currentStep;
+          const isCurrent = index === currentStep;
+          return (
+            <Box key={s.id} marginRight={1}>
+              <Text
+                color={isCompleted ? "green" : isCurrent ? "cyan" : "gray"}
+                bold={isCurrent}
+              >
+                {isCompleted ? "✓" : index + 1}. {s.title}
+                {index < steps.length - 1 && " →"}
+              </Text>
+            </Box>
+          );
+        })}
+      </Box>
+
+      {/* Step content */}
+      <Box
+        flexDirection="column"
+        borderStyle="round"
+        borderColor="gray"
+        padding={1}
+        marginBottom={1}
+      >
+        <Box marginBottom={1}>
+          <Text bold>
+            Step {currentStep + 1}: {step.title}
+          </Text>
+        </Box>
+        <StepComponent
+          isActive={!isSubmitting}
+          onFieldChange={handleFieldChange}
+          data={data}
+          setFieldFocus={setFocusedField}
+          focusedField={focusedField}
+        />
+      </Box>
+
+      {/* Error display */}
+      {error && (
+        <Box marginBottom={1}>
+          <Text color="red">Error: {error}</Text>
+        </Box>
+      )}
+
+      {/* Navigation */}
+      <Box>
+        <Text dimColor>
+          {isSubmitting ? (
+            "Submitting..."
+          ) : (
+            <>
+              [Esc] {isFirstStep ? "Cancel" : "Back"} | [Ctrl+N] {isLastStep ? "Create" : "Next"}
+              {!isFirstStep && " | [Ctrl+P] Previous"}
+            </>
+          )}
+        </Text>
+      </Box>
+    </Box>
+  );
+}

--- a/src/components/wizard/index.ts
+++ b/src/components/wizard/index.ts
@@ -1,0 +1,1 @@
+export { Wizard, type WizardProps, type WizardStep, type WizardStepProps } from "./Wizard.tsx";

--- a/src/views/CreateLXC.tsx
+++ b/src/views/CreateLXC.tsx
@@ -1,0 +1,747 @@
+import React, { useState, useEffect, useCallback } from "react";
+import { Box, Text, useInput } from "ink";
+import { Wizard, type WizardStep, type WizardStepProps } from "../components/wizard/index.ts";
+import { TextInput, Select, NumberInput, Checkbox, type SelectOption } from "../components/forms/index.ts";
+import { Spinner } from "../components/common/Spinner.tsx";
+import { getClient } from "../api/client.ts";
+import type { Node, Storage, StorageContent, AvailableTemplate, LXCCreateConfig } from "../api/types.ts";
+
+interface CreateLXCProps {
+  onComplete: () => void;
+  onCancel: () => void;
+}
+
+// Helper to format template name for display
+function formatTemplateName(volid: string): string {
+  // Extract filename from volid (e.g., "local:vztmpl/debian-12-standard_12.2-1_amd64.tar.zst")
+  const parts = volid.split("/");
+  const filename = parts[parts.length - 1] || volid;
+  return filename
+    .replace(".tar.zst", "")
+    .replace(".tar.gz", "")
+    .replace(".tar.xz", "")
+    .replace("_amd64", "")
+    .replace("_arm64", "");
+}
+
+// Step 1: Basic Configuration
+function BasicStep({ isActive, onFieldChange, data, setFieldFocus, focusedField }: WizardStepProps) {
+  const [nodes, setNodes] = useState<Node[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [nextVMID, setNextVMID] = useState<number | null>(null);
+  const [selectOpen, setSelectOpen] = useState(false);
+
+  useEffect(() => {
+    async function loadData() {
+      try {
+        const [nodesData, vmidData] = await Promise.all([
+          getClient().getNodes(),
+          getClient().getNextVMID(),
+        ]);
+        setNodes(nodesData);
+        setNextVMID(vmidData);
+        if (!data.node && nodesData.length > 0 && nodesData[0]) {
+          onFieldChange("node", nodesData[0].node);
+        }
+        if (!data.vmid && vmidData) {
+          onFieldChange("vmid", vmidData);
+        }
+      } catch (err) {
+        console.error("Failed to load nodes:", err);
+      } finally {
+        setLoading(false);
+      }
+    }
+    loadData();
+  }, []);
+
+  useInput((input, key) => {
+    if (!isActive) return;
+    // Navigate fields with Tab
+    if (key.tab && !key.shift) {
+      setFieldFocus((focusedField + 1) % 3);
+    } else if (key.tab && key.shift) {
+      setFieldFocus((focusedField - 1 + 3) % 3);
+    } else if (focusedField === 0 && !selectOpen) {
+      // j/k navigation only on Select field when dropdown is closed
+      if (key.downArrow || input === "j") {
+        setFieldFocus((focusedField + 1) % 3);
+      } else if (key.upArrow || input === "k") {
+        setFieldFocus((focusedField - 1 + 3) % 3);
+      }
+    }
+  }, { isActive });
+
+  if (loading) {
+    return <Spinner label="Loading nodes..." />;
+  }
+
+  const nodeOptions: SelectOption<string>[] = nodes.map((n) => ({
+    label: n.node,
+    value: n.node,
+    description: n.status === "online" ? "Online" : "Offline",
+  }));
+
+  return (
+    <Box flexDirection="column" gap={1}>
+      <Select
+        label="Node"
+        options={nodeOptions}
+        value={(data.node as string) || null}
+        onChange={(v) => onFieldChange("node", v)}
+        isActive={isActive && focusedField === 0}
+        placeholder="Select a node..."
+        onOpenChange={setSelectOpen}
+      />
+      {nodes.length > 0 && (
+        <Text dimColor>({nodes.length} nodes available)</Text>
+      )}
+      <NumberInput
+        label="CT ID"
+        value={(data.vmid as number) || null}
+        onChange={(v) => onFieldChange("vmid", v)}
+        min={100}
+        max={999999999}
+        isActive={isActive && focusedField === 1}
+        placeholder={nextVMID?.toString() || "100"}
+      />
+      <TextInput
+        label="Hostname"
+        value={(data.hostname as string) || ""}
+        onChange={(v) => onFieldChange("hostname", v)}
+        isActive={isActive && focusedField === 2}
+        placeholder="my-container"
+        required
+      />
+      <Text dimColor>Tab to move between fields</Text>
+    </Box>
+  );
+}
+
+// Step 2: Template Selection
+function TemplateStep({ isActive, onFieldChange, data, setFieldFocus, focusedField }: WizardStepProps) {
+  const [templates, setTemplates] = useState<StorageContent[]>([]);
+  const [availableTemplates, setAvailableTemplates] = useState<AvailableTemplate[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showDownload, setShowDownload] = useState(false);
+  const [downloading, setDownloading] = useState(false);
+  const [downloadError, setDownloadError] = useState<string | null>(null);
+  const [templateStorages, setTemplateStorages] = useState<Storage[]>([]);
+  const [selectOpen, setSelectOpen] = useState(false);
+
+  const node = data.node as string;
+
+  useEffect(() => {
+    async function loadTemplates() {
+      if (!node) return;
+      setLoading(true);
+      try {
+        const [localTemplates, remoteTemplates, storages] = await Promise.all([
+          getClient().getAllTemplates(node),
+          getClient().getAvailableTemplates(node).catch(() => []),
+          getClient().getTemplateStorages(node),
+        ]);
+        setTemplates(localTemplates);
+        setAvailableTemplates(remoteTemplates);
+        setTemplateStorages(storages);
+        if (!data.templateStorage && storages.length > 0 && storages[0]) {
+          onFieldChange("templateStorage", storages[0].storage);
+        }
+      } catch (err) {
+        console.error("Failed to load templates:", err);
+      } finally {
+        setLoading(false);
+      }
+    }
+    loadTemplates();
+  }, [node]);
+
+  useInput((input, key) => {
+    if (!isActive) return;
+    if (input === "d" && !showDownload) {
+      setShowDownload(true);
+      setFieldFocus(0);
+    } else if (key.escape && showDownload) {
+      setShowDownload(false);
+      setFieldFocus(0);
+    } else if (!selectOpen && showDownload) {
+      // Navigate between fields when dropdown is closed
+      if (key.tab && !key.shift) {
+        setFieldFocus((focusedField + 1) % 2);
+      } else if (key.downArrow || input === "j") {
+        setFieldFocus((focusedField + 1) % 2);
+      } else if (key.upArrow || input === "k") {
+        setFieldFocus((focusedField - 1 + 2) % 2);
+      }
+    }
+  }, { isActive });
+
+  const handleDownload = useCallback(async (template: string) => {
+    const storage = data.templateStorage as string;
+    if (!storage || !node) return;
+
+    setDownloading(true);
+    setDownloadError(null);
+    try {
+      await getClient().downloadTemplate(node, storage, template);
+      // Refresh templates after download starts
+      setTimeout(async () => {
+        const localTemplates = await getClient().getAllTemplates(node);
+        setTemplates(localTemplates);
+        setDownloading(false);
+        setShowDownload(false);
+      }, 2000);
+    } catch (err) {
+      setDownloadError(err instanceof Error ? err.message : "Download failed");
+      setDownloading(false);
+    }
+  }, [node, data.templateStorage]);
+
+  // Memoize options to prevent recreation on each render
+  // Must be before any conditional returns (Rules of Hooks)
+  const downloadOptions = React.useMemo(() =>
+    availableTemplates
+      .filter((t) => t.type === "lxc")
+      .slice(0, 100) // Show more templates
+      .map((t) => ({
+        label: `${t.os} - ${t.package}`,
+        value: t.template,
+        description: t.headline,
+      })),
+    [availableTemplates]
+  );
+
+  const storageOptions = React.useMemo(() =>
+    templateStorages.map((s) => ({
+      label: s.storage,
+      value: s.storage,
+    })),
+    [templateStorages]
+  );
+
+  if (loading) {
+    return <Spinner label="Loading templates..." />;
+  }
+
+  if (showDownload) {
+    return (
+      <Box flexDirection="column" gap={1}>
+        <Text bold color="yellow">Download Template from Proxmox Repository</Text>
+        {downloadError && <Text color="red">Error: {downloadError}</Text>}
+        {downloading ? (
+          <Spinner label="Starting download..." />
+        ) : (
+          <>
+            <Select
+              label="Storage"
+              options={storageOptions}
+              value={(data.templateStorage as string) || null}
+              onChange={(v) => onFieldChange("templateStorage", v)}
+              isActive={isActive && focusedField === 0}
+              onOpenChange={setSelectOpen}
+            />
+            <Select
+              label="Template"
+              options={downloadOptions}
+              value={(data.downloadTemplate as string) || null}
+              onChange={(v) => {
+                onFieldChange("downloadTemplate", v);
+                handleDownload(v);
+              }}
+              isActive={isActive && focusedField === 1}
+              placeholder="Select a template to download..."
+              onOpenChange={setSelectOpen}
+            />
+            <Text dimColor>Tab to navigate, Enter to select, [Esc] Cancel</Text>
+          </>
+        )}
+      </Box>
+    );
+  }
+
+  const templateOptions: SelectOption<string>[] = templates.map((t) => ({
+    label: formatTemplateName(t.volid),
+    value: t.volid,
+  }));
+
+  return (
+    <Box flexDirection="column" gap={1}>
+      {templates.length === 0 ? (
+        <Box flexDirection="column">
+          <Text color="yellow">No local templates found.</Text>
+          <Text dimColor>Press 'd' to download a template from the Proxmox repository.</Text>
+        </Box>
+      ) : (
+        <>
+          <Select
+            label="Template"
+            options={templateOptions}
+            value={(data.ostemplate as string) || null}
+            onChange={(v) => onFieldChange("ostemplate", v)}
+            isActive={isActive && focusedField === 0}
+            placeholder="Select a template..."
+          />
+          <Text dimColor>[d] Download new template</Text>
+        </>
+      )}
+    </Box>
+  );
+}
+
+// Step 3: Authentication
+function AuthStep({ isActive, onFieldChange, data, setFieldFocus, focusedField }: WizardStepProps) {
+  useInput((input, key) => {
+    if (!isActive) return;
+    if (key.tab && !key.shift) {
+      setFieldFocus((focusedField + 1) % 2);
+    } else if (key.tab && key.shift) {
+      setFieldFocus((focusedField - 1 + 2) % 2);
+    }
+  }, { isActive });
+
+  return (
+    <Box flexDirection="column" gap={1}>
+      <TextInput
+        label="Root Password"
+        value={(data.password as string) || ""}
+        onChange={(v) => onFieldChange("password", v)}
+        isActive={isActive && focusedField === 0}
+        password
+        placeholder="Enter root password"
+        required
+      />
+      <TextInput
+        label="SSH Public Key"
+        value={(data.sshKey as string) || ""}
+        onChange={(v) => onFieldChange("sshKey", v)}
+        isActive={isActive && focusedField === 1}
+        placeholder="ssh-rsa AAAA... (optional)"
+        width={60}
+      />
+      <Text dimColor>Tab to move between fields</Text>
+    </Box>
+  );
+}
+
+// Step 4: Resources
+function ResourcesStep({ isActive, onFieldChange, data, setFieldFocus, focusedField }: WizardStepProps) {
+  // Set defaults
+  useEffect(() => {
+    if (data.cores === undefined) onFieldChange("cores", 1);
+    if (data.memory === undefined) onFieldChange("memory", 512);
+    if (data.swap === undefined) onFieldChange("swap", 512);
+  }, []);
+
+  useInput((input, key) => {
+    if (!isActive) return;
+    if (key.tab && !key.shift) {
+      setFieldFocus((focusedField + 1) % 3);
+    } else if (key.tab && key.shift) {
+      setFieldFocus((focusedField - 1 + 3) % 3);
+    }
+  }, { isActive });
+
+  return (
+    <Box flexDirection="column" gap={1}>
+      <NumberInput
+        label="CPU Cores"
+        value={(data.cores as number) ?? 1}
+        onChange={(v) => onFieldChange("cores", v)}
+        min={1}
+        max={128}
+        isActive={isActive && focusedField === 0}
+      />
+      <NumberInput
+        label="Memory"
+        value={(data.memory as number) ?? 512}
+        onChange={(v) => onFieldChange("memory", v)}
+        min={16}
+        max={131072}
+        unit="MB"
+        step={128}
+        isActive={isActive && focusedField === 1}
+      />
+      <NumberInput
+        label="Swap"
+        value={(data.swap as number) ?? 512}
+        onChange={(v) => onFieldChange("swap", v)}
+        min={0}
+        max={131072}
+        unit="MB"
+        step={128}
+        isActive={isActive && focusedField === 2}
+      />
+      <Text dimColor>Tab to move between fields. Use arrow keys to adjust values.</Text>
+    </Box>
+  );
+}
+
+// Step 5: Storage
+function StorageStep({ isActive, onFieldChange, data, setFieldFocus, focusedField }: WizardStepProps) {
+  const [storages, setStorages] = useState<Storage[]>([]);
+  const [loading, setLoading] = useState(true);
+  const node = data.node as string;
+
+  useEffect(() => {
+    async function loadStorages() {
+      if (!node) return;
+      try {
+        const rootfsStorages = await getClient().getRootfsStorages(node);
+        setStorages(rootfsStorages);
+        if (!data.rootfsStorage && rootfsStorages.length > 0 && rootfsStorages[0]) {
+          onFieldChange("rootfsStorage", rootfsStorages[0].storage);
+        }
+        if (data.rootfsSize === undefined) {
+          onFieldChange("rootfsSize", 8);
+        }
+      } catch (err) {
+        console.error("Failed to load storages:", err);
+      } finally {
+        setLoading(false);
+      }
+    }
+    loadStorages();
+  }, [node]);
+
+  useInput((input, key) => {
+    if (!isActive) return;
+    if (key.tab && !key.shift) {
+      setFieldFocus((focusedField + 1) % 2);
+    } else if (key.tab && key.shift) {
+      setFieldFocus((focusedField - 1 + 2) % 2);
+    }
+  }, { isActive });
+
+  if (loading) {
+    return <Spinner label="Loading storage options..." />;
+  }
+
+  const storageOptions: SelectOption<string>[] = storages.map((s) => ({
+    label: s.storage,
+    value: s.storage,
+    description: `${s.type} - ${Math.round(s.avail / 1024 / 1024 / 1024)}GB free`,
+  }));
+
+  return (
+    <Box flexDirection="column" gap={1}>
+      <Select
+        label="Root Disk Storage"
+        options={storageOptions}
+        value={(data.rootfsStorage as string) || null}
+        onChange={(v) => onFieldChange("rootfsStorage", v)}
+        isActive={isActive && focusedField === 0}
+        placeholder="Select storage..."
+      />
+      <NumberInput
+        label="Root Disk Size"
+        value={(data.rootfsSize as number) ?? 8}
+        onChange={(v) => onFieldChange("rootfsSize", v)}
+        min={1}
+        max={10240}
+        unit="GB"
+        step={1}
+        isActive={isActive && focusedField === 1}
+      />
+      <Text dimColor>Tab to move between fields</Text>
+    </Box>
+  );
+}
+
+// Step 6: Network
+function NetworkStep({ isActive, onFieldChange, data, setFieldFocus, focusedField }: WizardStepProps) {
+  const [bridges, setBridges] = useState<{ iface: string }[]>([]);
+  const [loading, setLoading] = useState(true);
+  const node = data.node as string;
+
+  useEffect(() => {
+    async function loadBridges() {
+      if (!node) return;
+      try {
+        const networkBridges = await getClient().getNetworkBridges(node);
+        setBridges(networkBridges);
+        if (!data.bridge && networkBridges.length > 0 && networkBridges[0]) {
+          onFieldChange("bridge", networkBridges[0].iface);
+        }
+        if (data.ipType === undefined) {
+          onFieldChange("ipType", "dhcp");
+        }
+      } catch (err) {
+        console.error("Failed to load bridges:", err);
+      } finally {
+        setLoading(false);
+      }
+    }
+    loadBridges();
+  }, [node]);
+
+  const ipType = data.ipType as string;
+  const fieldCount = ipType === "static" ? 6 : 4;
+
+  useInput((input, key) => {
+    if (!isActive) return;
+    if (key.tab && !key.shift) {
+      setFieldFocus((focusedField + 1) % fieldCount);
+    } else if (key.tab && key.shift) {
+      setFieldFocus((focusedField - 1 + fieldCount) % fieldCount);
+    }
+  }, { isActive });
+
+  if (loading) {
+    return <Spinner label="Loading network options..." />;
+  }
+
+  const bridgeOptions: SelectOption<string>[] = bridges.map((b) => ({
+    label: b.iface,
+    value: b.iface,
+  }));
+
+  const ipTypeOptions: SelectOption<string>[] = [
+    { label: "DHCP", value: "dhcp" },
+    { label: "Static IP", value: "static" },
+  ];
+
+  let currentField = 0;
+
+  return (
+    <Box flexDirection="column" gap={1}>
+      <Select
+        label="Bridge"
+        options={bridgeOptions}
+        value={(data.bridge as string) || null}
+        onChange={(v) => onFieldChange("bridge", v)}
+        isActive={isActive && focusedField === currentField++}
+        placeholder="Select bridge..."
+      />
+      <Select
+        label="IP Configuration"
+        options={ipTypeOptions}
+        value={(data.ipType as string) || "dhcp"}
+        onChange={(v) => onFieldChange("ipType", v)}
+        isActive={isActive && focusedField === currentField++}
+      />
+      {ipType === "static" && (
+        <>
+          <TextInput
+            label="IP Address"
+            value={(data.ip as string) || ""}
+            onChange={(v) => onFieldChange("ip", v)}
+            isActive={isActive && focusedField === currentField++}
+            placeholder="192.168.1.100/24"
+            required
+          />
+          <TextInput
+            label="Gateway"
+            value={(data.gateway as string) || ""}
+            onChange={(v) => onFieldChange("gateway", v)}
+            isActive={isActive && focusedField === currentField++}
+            placeholder="192.168.1.1"
+            required
+          />
+        </>
+      )}
+      <TextInput
+        label="DNS Server"
+        value={(data.nameserver as string) || ""}
+        onChange={(v) => onFieldChange("nameserver", v)}
+        isActive={isActive && focusedField === currentField++}
+        placeholder="8.8.8.8 (optional)"
+      />
+      <TextInput
+        label="Search Domain"
+        value={(data.searchdomain as string) || ""}
+        onChange={(v) => onFieldChange("searchdomain", v)}
+        isActive={isActive && focusedField === currentField++}
+        placeholder="local (optional)"
+      />
+      <Text dimColor>Tab to move between fields</Text>
+    </Box>
+  );
+}
+
+// Step 7: Options
+function OptionsStep({ isActive, onFieldChange, data, setFieldFocus, focusedField }: WizardStepProps) {
+  // Set defaults
+  useEffect(() => {
+    if (data.unprivileged === undefined) onFieldChange("unprivileged", true);
+    if (data.start === undefined) onFieldChange("start", false);
+    if (data.nesting === undefined) onFieldChange("nesting", false);
+    if (data.onboot === undefined) onFieldChange("onboot", false);
+  }, []);
+
+  useInput((input, key) => {
+    if (!isActive) return;
+    if (key.tab && !key.shift) {
+      setFieldFocus((focusedField + 1) % 4);
+    } else if (key.tab && key.shift) {
+      setFieldFocus((focusedField - 1 + 4) % 4);
+    }
+  }, { isActive });
+
+  return (
+    <Box flexDirection="column" gap={1}>
+      <Checkbox
+        label="Unprivileged container"
+        checked={(data.unprivileged as boolean) ?? true}
+        onChange={(v) => onFieldChange("unprivileged", v)}
+        isActive={isActive && focusedField === 0}
+        description="Recommended for security"
+      />
+      <Checkbox
+        label="Start after creation"
+        checked={(data.start as boolean) ?? false}
+        onChange={(v) => onFieldChange("start", v)}
+        isActive={isActive && focusedField === 1}
+      />
+      <Checkbox
+        label="Enable nesting"
+        checked={(data.nesting as boolean) ?? false}
+        onChange={(v) => onFieldChange("nesting", v)}
+        isActive={isActive && focusedField === 2}
+        description="Required for Docker inside container"
+      />
+      <Checkbox
+        label="Start on boot"
+        checked={(data.onboot as boolean) ?? false}
+        onChange={(v) => onFieldChange("onboot", v)}
+        isActive={isActive && focusedField === 3}
+      />
+      <Text dimColor>Tab to move between fields. Space/Enter to toggle.</Text>
+    </Box>
+  );
+}
+
+export function CreateLXC({ onComplete, onCancel }: CreateLXCProps) {
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const steps: WizardStep[] = [
+    {
+      id: "basic",
+      title: "Basic",
+      component: BasicStep,
+      validate: function() {
+        // Access data through closure - this is handled by Wizard
+        return true;
+      },
+    },
+    {
+      id: "template",
+      title: "Template",
+      component: TemplateStep,
+    },
+    {
+      id: "auth",
+      title: "Authentication",
+      component: AuthStep,
+    },
+    {
+      id: "resources",
+      title: "Resources",
+      component: ResourcesStep,
+    },
+    {
+      id: "storage",
+      title: "Storage",
+      component: StorageStep,
+    },
+    {
+      id: "network",
+      title: "Network",
+      component: NetworkStep,
+    },
+    {
+      id: "options",
+      title: "Options",
+      component: OptionsStep,
+    },
+  ];
+
+  const handleComplete = async (data: Record<string, unknown>) => {
+    setCreating(true);
+    setError(null);
+
+    try {
+      const node = data.node as string;
+
+      // Build network configuration string
+      let net0 = `name=eth0,bridge=${data.bridge || "vmbr0"}`;
+      if (data.ipType === "dhcp") {
+        net0 += ",ip=dhcp";
+      } else if (data.ipType === "static" && data.ip) {
+        net0 += `,ip=${data.ip}`;
+        if (data.gateway) {
+          net0 += `,gw=${data.gateway}`;
+        }
+      }
+
+      // Build features string
+      const features: string[] = [];
+      if (data.nesting) {
+        features.push("nesting=1");
+      }
+
+      const config: LXCCreateConfig = {
+        vmid: data.vmid as number,
+        hostname: data.hostname as string,
+        ostemplate: data.ostemplate as string,
+        password: data.password as string,
+        cores: data.cores as number,
+        memory: data.memory as number,
+        swap: data.swap as number,
+        rootfs: `${data.rootfsStorage}:${data.rootfsSize}`,
+        net0,
+        unprivileged: data.unprivileged as boolean,
+        start: data.start as boolean,
+        onboot: data.onboot as boolean,
+      };
+
+      if (data.sshKey) {
+        config["ssh-public-keys"] = data.sshKey as string;
+      }
+      if (data.nameserver) {
+        config.nameserver = data.nameserver as string;
+      }
+      if (data.searchdomain) {
+        config.searchdomain = data.searchdomain as string;
+      }
+      if (features.length > 0) {
+        config.features = features.join(",");
+      }
+
+      await getClient().createContainer(node, config);
+      onComplete();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create container");
+      setCreating(false);
+    }
+  };
+
+  if (creating) {
+    return (
+      <Box flexDirection="column" padding={1}>
+        <Spinner label="Creating container..." />
+        {error && <Text color="red">Error: {error}</Text>}
+      </Box>
+    );
+  }
+
+  return (
+    <Wizard
+      title="Create LXC Container"
+      steps={steps}
+      onComplete={handleComplete}
+      onCancel={onCancel}
+      initialData={{
+        cores: 1,
+        memory: 512,
+        swap: 512,
+        rootfsSize: 8,
+        ipType: "dhcp",
+        unprivileged: true,
+        start: false,
+        nesting: false,
+        onboot: false,
+      }}
+    />
+  );
+}

--- a/src/views/CreateVM.tsx
+++ b/src/views/CreateVM.tsx
@@ -1,0 +1,586 @@
+import React, { useState, useEffect, useCallback } from "react";
+import { Box, Text, useInput } from "ink";
+import { Wizard, type WizardStep, type WizardStepProps } from "../components/wizard/index.ts";
+import { TextInput, Select, NumberInput, Checkbox, type SelectOption } from "../components/forms/index.ts";
+import { Spinner } from "../components/common/Spinner.tsx";
+import { getClient } from "../api/client.ts";
+import type { Node, Storage, StorageContent, VMOsType, VMNetModel, VMDiskFormat, VMCreateConfig } from "../api/types.ts";
+
+interface CreateVMProps {
+  onComplete: () => void;
+  onCancel: () => void;
+}
+
+// OS Type options
+const osTypeOptions: SelectOption<VMOsType>[] = [
+  { label: "Linux 6.x/5.x/4.x/3.x/2.6 Kernel", value: "l26" },
+  { label: "Linux 2.4 Kernel", value: "l24" },
+  { label: "Windows 11", value: "win11" },
+  { label: "Windows 10", value: "win10" },
+  { label: "Windows Server 2022", value: "w2k22" },
+  { label: "Windows Server 2019", value: "w2k19" },
+  { label: "Windows Server 2016", value: "w2k16" },
+  { label: "Windows Server 2012", value: "w2k12" },
+  { label: "Windows 8.x", value: "win8" },
+  { label: "Windows 7", value: "win7" },
+  { label: "Windows Vista", value: "wvista" },
+  { label: "Windows XP", value: "wxp" },
+  { label: "Solaris", value: "solaris" },
+  { label: "Other", value: "other" },
+];
+
+// Network model options
+const netModelOptions: SelectOption<VMNetModel>[] = [
+  { label: "VirtIO (paravirtualized)", value: "virtio", description: "Best performance" },
+  { label: "Intel E1000", value: "e1000", description: "Wide compatibility" },
+  { label: "Realtek RTL8139", value: "rtl8139", description: "Legacy support" },
+  { label: "VMware vmxnet3", value: "vmxnet3", description: "VMware compatibility" },
+];
+
+// Disk format options
+const diskFormatOptions: SelectOption<VMDiskFormat>[] = [
+  { label: "QCOW2", value: "qcow2", description: "Recommended, supports snapshots" },
+  { label: "Raw", value: "raw", description: "Best performance" },
+  { label: "VMDK", value: "vmdk", description: "VMware compatibility" },
+];
+
+// Step 1: Basic configuration
+function BasicStep({ isActive, onFieldChange, data, setFieldFocus, focusedField }: WizardStepProps) {
+  const nodes = (data._nodes as Node[]) || [];
+  const nextVmid = data._nextVmid as number | undefined;
+
+  const nodeOptions: SelectOption<string>[] = nodes.map((n) => ({
+    label: n.node,
+    value: n.node,
+    description: n.status === "online" ? "Online" : "Offline",
+  }));
+
+  useInput(
+    (input, key) => {
+      if (!isActive) return;
+      if (key.tab || key.downArrow) {
+        setFieldFocus((focusedField + 1) % 3);
+      } else if (key.upArrow) {
+        setFieldFocus((focusedField - 1 + 3) % 3);
+      }
+    },
+    { isActive }
+  );
+
+  return (
+    <Box flexDirection="column" gap={1}>
+      <Select
+        label="Node"
+        options={nodeOptions}
+        value={(data.node as string) || null}
+        onChange={(v) => onFieldChange("node", v)}
+        isActive={isActive && focusedField === 0}
+        placeholder="Select a node..."
+      />
+      <Box gap={1}>
+        <NumberInput
+          label="VM ID"
+          value={(data.vmid as number) ?? nextVmid ?? null}
+          onChange={(v) => onFieldChange("vmid", v)}
+          min={100}
+          max={999999999}
+          isActive={isActive && focusedField === 1}
+          placeholder={nextVmid?.toString() || ""}
+        />
+        {nextVmid && (
+          <Text dimColor>(Next available: {nextVmid})</Text>
+        )}
+      </Box>
+      <TextInput
+        label="Name"
+        value={(data.name as string) || ""}
+        onChange={(v) => onFieldChange("name", v)}
+        isActive={isActive && focusedField === 2}
+        placeholder="my-vm"
+        required
+      />
+    </Box>
+  );
+}
+
+// Step 2: OS configuration
+function OSStep({ isActive, onFieldChange, data, setFieldFocus, focusedField }: WizardStepProps) {
+  const isoStorages = (data._isoStorages as Storage[]) || [];
+  const isos = (data._isos as StorageContent[]) || [];
+  const [loadingIsos, setLoadingIsos] = useState(false);
+
+  const isoStorageOptions: SelectOption<string>[] = isoStorages.map((s) => ({
+    label: s.storage,
+    value: s.storage,
+    description: `${s.type}`,
+  }));
+
+  const isoOptions: SelectOption<string>[] = isos.map((iso) => ({
+    label: iso.volid.split("/").pop() || iso.volid,
+    value: iso.volid,
+  }));
+
+  // Load ISOs when storage changes
+  useEffect(() => {
+    const node = data.node as string;
+    const isoStorage = data.isoStorage as string;
+    if (node && isoStorage && isActive) {
+      setLoadingIsos(true);
+      getClient()
+        .getIsos(node, isoStorage)
+        .then((result) => {
+          onFieldChange("_isos", result);
+        })
+        .catch(() => {
+          onFieldChange("_isos", []);
+        })
+        .finally(() => setLoadingIsos(false));
+    }
+  }, [data.node, data.isoStorage, isActive, onFieldChange]);
+
+  useInput(
+    (input, key) => {
+      if (!isActive) return;
+      if (key.tab || key.downArrow) {
+        setFieldFocus((focusedField + 1) % 3);
+      } else if (key.upArrow) {
+        setFieldFocus((focusedField - 1 + 3) % 3);
+      }
+    },
+    { isActive }
+  );
+
+  return (
+    <Box flexDirection="column" gap={1}>
+      <Select
+        label="ISO Storage"
+        options={isoStorageOptions}
+        value={(data.isoStorage as string) || null}
+        onChange={(v) => {
+          onFieldChange("isoStorage", v);
+          onFieldChange("iso", null);
+          onFieldChange("_isos", []);
+        }}
+        isActive={isActive && focusedField === 0}
+        placeholder="Select storage..."
+      />
+      {loadingIsos ? (
+        <Box>
+          <Text dimColor>Loading ISOs...</Text>
+        </Box>
+      ) : (
+        <Select
+          label="ISO Image"
+          options={isoOptions}
+          value={(data.iso as string) || null}
+          onChange={(v) => onFieldChange("iso", v)}
+          isActive={isActive && focusedField === 1}
+          placeholder={isos.length === 0 ? "No ISOs found" : "Select an ISO..."}
+        />
+      )}
+      <Select
+        label="OS Type"
+        options={osTypeOptions}
+        value={(data.ostype as VMOsType) || null}
+        onChange={(v) => onFieldChange("ostype", v)}
+        isActive={isActive && focusedField === 2}
+        placeholder="Select OS type..."
+      />
+    </Box>
+  );
+}
+
+// Step 3: CPU configuration
+function CPUStep({ isActive, onFieldChange, data, setFieldFocus, focusedField }: WizardStepProps) {
+  useInput(
+    (input, key) => {
+      if (!isActive) return;
+      if (key.tab || key.downArrow) {
+        setFieldFocus((focusedField + 1) % 2);
+      } else if (key.upArrow) {
+        setFieldFocus((focusedField - 1 + 2) % 2);
+      }
+    },
+    { isActive }
+  );
+
+  return (
+    <Box flexDirection="column" gap={1}>
+      <NumberInput
+        label="CPU Cores"
+        value={(data.cores as number) ?? 1}
+        onChange={(v) => onFieldChange("cores", v)}
+        min={1}
+        max={128}
+        step={1}
+        isActive={isActive && focusedField === 0}
+      />
+      <NumberInput
+        label="CPU Sockets"
+        value={(data.sockets as number) ?? 1}
+        onChange={(v) => onFieldChange("sockets", v)}
+        min={1}
+        max={4}
+        step={1}
+        isActive={isActive && focusedField === 1}
+      />
+      <Text dimColor>
+        Total vCPUs: {((data.cores as number) || 1) * ((data.sockets as number) || 1)}
+      </Text>
+    </Box>
+  );
+}
+
+// Step 4: Memory configuration
+function MemoryStep({ isActive, onFieldChange, data, setFieldFocus, focusedField }: WizardStepProps) {
+  useInput(
+    (input, key) => {
+      if (!isActive) return;
+      // Only one field, no navigation needed
+    },
+    { isActive }
+  );
+
+  const memoryMB = (data.memory as number) || 2048;
+  const memoryGB = (memoryMB / 1024).toFixed(1);
+
+  return (
+    <Box flexDirection="column" gap={1}>
+      <NumberInput
+        label="Memory"
+        value={memoryMB}
+        onChange={(v) => onFieldChange("memory", v)}
+        min={128}
+        max={1048576}
+        step={512}
+        unit="MB"
+        isActive={isActive && focusedField === 0}
+      />
+      <Text dimColor>= {memoryGB} GB</Text>
+    </Box>
+  );
+}
+
+// Step 5: Disk configuration
+function DiskStep({ isActive, onFieldChange, data, setFieldFocus, focusedField }: WizardStepProps) {
+  const diskStorages = (data._diskStorages as Storage[]) || [];
+
+  const diskStorageOptions: SelectOption<string>[] = diskStorages.map((s) => ({
+    label: s.storage,
+    value: s.storage,
+    description: `${s.type} - ${Math.round(s.avail / 1024 / 1024 / 1024)} GB free`,
+  }));
+
+  useInput(
+    (input, key) => {
+      if (!isActive) return;
+      if (key.tab || key.downArrow) {
+        setFieldFocus((focusedField + 1) % 3);
+      } else if (key.upArrow) {
+        setFieldFocus((focusedField - 1 + 3) % 3);
+      }
+    },
+    { isActive }
+  );
+
+  return (
+    <Box flexDirection="column" gap={1}>
+      <Select
+        label="Storage"
+        options={diskStorageOptions}
+        value={(data.diskStorage as string) || null}
+        onChange={(v) => onFieldChange("diskStorage", v)}
+        isActive={isActive && focusedField === 0}
+        placeholder="Select storage..."
+      />
+      <NumberInput
+        label="Disk Size"
+        value={(data.diskSize as number) ?? 32}
+        onChange={(v) => onFieldChange("diskSize", v)}
+        min={1}
+        max={10240}
+        step={8}
+        unit="GB"
+        isActive={isActive && focusedField === 1}
+      />
+      <Select
+        label="Format"
+        options={diskFormatOptions}
+        value={(data.diskFormat as VMDiskFormat) || "qcow2"}
+        onChange={(v) => onFieldChange("diskFormat", v)}
+        isActive={isActive && focusedField === 2}
+      />
+    </Box>
+  );
+}
+
+// Step 6: Network configuration
+function NetworkStep({ isActive, onFieldChange, data, setFieldFocus, focusedField }: WizardStepProps) {
+  const bridges = (data._bridges as string[]) || [];
+
+  const bridgeOptions: SelectOption<string>[] = bridges.map((b) => ({
+    label: b,
+    value: b,
+  }));
+
+  useInput(
+    (input, key) => {
+      if (!isActive) return;
+      if (key.tab || key.downArrow) {
+        setFieldFocus((focusedField + 1) % 3);
+      } else if (key.upArrow) {
+        setFieldFocus((focusedField - 1 + 3) % 3);
+      }
+    },
+    { isActive }
+  );
+
+  return (
+    <Box flexDirection="column" gap={1}>
+      <Select
+        label="Bridge"
+        options={bridgeOptions}
+        value={(data.bridge as string) || null}
+        onChange={(v) => onFieldChange("bridge", v)}
+        isActive={isActive && focusedField === 0}
+        placeholder="Select bridge..."
+      />
+      <Select
+        label="Model"
+        options={netModelOptions}
+        value={(data.netModel as VMNetModel) || "virtio"}
+        onChange={(v) => onFieldChange("netModel", v)}
+        isActive={isActive && focusedField === 1}
+      />
+      <TextInput
+        label="MAC Address"
+        value={(data.macaddr as string) || ""}
+        onChange={(v) => onFieldChange("macaddr", v)}
+        isActive={isActive && focusedField === 2}
+        placeholder="auto-generate"
+      />
+    </Box>
+  );
+}
+
+// Step 7: Options
+function OptionsStep({ isActive, onFieldChange, data, setFieldFocus, focusedField }: WizardStepProps) {
+  useInput(
+    (input, key) => {
+      if (!isActive) return;
+      if (key.tab || key.downArrow) {
+        setFieldFocus((focusedField + 1) % 2);
+      } else if (key.upArrow) {
+        setFieldFocus((focusedField - 1 + 2) % 2);
+      }
+    },
+    { isActive }
+  );
+
+  return (
+    <Box flexDirection="column" gap={1}>
+      <Checkbox
+        label="Start after creation"
+        checked={(data.startAfterCreate as boolean) ?? false}
+        onChange={(v) => onFieldChange("startAfterCreate", v)}
+        isActive={isActive && focusedField === 0}
+        description="Automatically start the VM after it is created"
+      />
+      <Box marginTop={1}>
+        <Text dimColor>Boot order: Disk, CD-ROM, Network</Text>
+      </Box>
+
+      {/* Summary */}
+      <Box flexDirection="column" marginTop={1} borderStyle="single" borderColor="gray" padding={1}>
+        <Text bold>Summary:</Text>
+        <Text>Node: {(data.node as string) || "-"}</Text>
+        <Text>VMID: {(data.vmid as number) || "-"}</Text>
+        <Text>Name: {(data.name as string) || "-"}</Text>
+        <Text>OS: {osTypeOptions.find(o => o.value === data.ostype)?.label || "-"}</Text>
+        <Text>CPU: {(data.cores as number) || 1} cores x {(data.sockets as number) || 1} sockets</Text>
+        <Text>Memory: {(data.memory as number) || 2048} MB</Text>
+        <Text>Disk: {(data.diskSize as number) || 32} GB on {(data.diskStorage as string) || "-"}</Text>
+        <Text>Network: {(data.netModel as string) || "virtio"} on {(data.bridge as string) || "-"}</Text>
+      </Box>
+    </Box>
+  );
+}
+
+export function CreateVM({ onComplete, onCancel }: CreateVMProps) {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [initialData, setInitialData] = useState<Record<string, unknown>>({});
+
+  // Load initial data (nodes, next vmid, storages)
+  useEffect(() => {
+    async function loadInitialData() {
+      try {
+        const client = getClient();
+        const [nodes, nextVmid] = await Promise.all([
+          client.getNodes(),
+          client.getNextVmid(),
+        ]);
+
+        const onlineNodes = nodes.filter((n) => n.status === "online");
+        const firstNode = onlineNodes[0]?.node || nodes[0]?.node;
+
+        let isoStorages: Storage[] = [];
+        let diskStorages: Storage[] = [];
+        let bridges: string[] = [];
+
+        if (firstNode) {
+          [isoStorages, diskStorages, bridges] = await Promise.all([
+            client.getStoragesForContent(firstNode, "iso"),
+            client.getStoragesForContent(firstNode, "images"),
+            client.getNetworkBridges(firstNode),
+          ]);
+        }
+
+        setInitialData({
+          _nodes: nodes,
+          _nextVmid: nextVmid,
+          _isoStorages: isoStorages,
+          _diskStorages: diskStorages,
+          _bridges: bridges,
+          _isos: [],
+          node: firstNode || null,
+          vmid: nextVmid,
+          name: "",
+          ostype: "l26",
+          cores: 2,
+          sockets: 1,
+          memory: 2048,
+          diskStorage: diskStorages[0]?.storage || null,
+          diskSize: 32,
+          diskFormat: "qcow2",
+          bridge: bridges[0] || null,
+          netModel: "virtio",
+          macaddr: "",
+          startAfterCreate: false,
+        });
+        setLoading(false);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to load data");
+        setLoading(false);
+      }
+    }
+
+    loadInitialData();
+  }, []);
+
+  const handleComplete = useCallback(
+    async (data: Record<string, unknown>) => {
+      const client = getClient();
+      const node = data.node as string;
+
+      const config: VMCreateConfig = {
+        vmid: data.vmid as number,
+        name: data.name as string,
+        iso: data.iso as string | undefined,
+        ostype: (data.ostype as VMOsType) || "l26",
+        cores: (data.cores as number) || 2,
+        sockets: (data.sockets as number) || 1,
+        memory: (data.memory as number) || 2048,
+        disk: {
+          storage: data.diskStorage as string,
+          size: (data.diskSize as number) || 32,
+          format: (data.diskFormat as VMDiskFormat) || "qcow2",
+        },
+        network: {
+          bridge: data.bridge as string,
+          model: (data.netModel as VMNetModel) || "virtio",
+          macaddr: (data.macaddr as string) || undefined,
+        },
+        start: data.startAfterCreate as boolean,
+      };
+
+      await client.createVM(node, config);
+      onComplete();
+    },
+    [onComplete]
+  );
+
+  const steps: WizardStep[] = [
+    {
+      id: "basic",
+      title: "Basic",
+      component: BasicStep,
+      validate: () => {
+        const data = initialData;
+        if (!data.node) return "Please select a node";
+        if (!data.vmid) return "Please enter a VM ID";
+        if (!data.name) return "Please enter a name";
+        return true;
+      },
+    },
+    {
+      id: "os",
+      title: "OS",
+      component: OSStep,
+      validate: () => {
+        const data = initialData;
+        if (!data.ostype) return "Please select an OS type";
+        return true;
+      },
+    },
+    {
+      id: "cpu",
+      title: "CPU",
+      component: CPUStep,
+    },
+    {
+      id: "memory",
+      title: "Memory",
+      component: MemoryStep,
+    },
+    {
+      id: "disk",
+      title: "Disk",
+      component: DiskStep,
+      validate: () => {
+        const data = initialData;
+        if (!data.diskStorage) return "Please select a storage";
+        if (!data.diskSize || (data.diskSize as number) < 1) return "Please enter a valid disk size";
+        return true;
+      },
+    },
+    {
+      id: "network",
+      title: "Network",
+      component: NetworkStep,
+      validate: () => {
+        const data = initialData;
+        if (!data.bridge) return "Please select a network bridge";
+        return true;
+      },
+    },
+    {
+      id: "options",
+      title: "Options",
+      component: OptionsStep,
+    },
+  ];
+
+  if (loading) {
+    return <Spinner label="Loading configuration..." />;
+  }
+
+  if (error) {
+    return (
+      <Box flexDirection="column" padding={1}>
+        <Text color="red">Error: {error}</Text>
+        <Text dimColor>Press Esc to go back</Text>
+      </Box>
+    );
+  }
+
+  return (
+    <Wizard
+      title="Create Virtual Machine"
+      steps={steps}
+      onComplete={handleComplete}
+      onCancel={onCancel}
+      initialData={initialData}
+    />
+  );
+}

--- a/tests/api/client.test.ts
+++ b/tests/api/client.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
+import { ProxmoxClient } from "../../src/api/client";
+import type { ProxmuxConfig } from "../../src/config/index";
+
+// Mock config for testing
+const mockConfig: ProxmuxConfig = {
+  host: "https://proxmox.example.com:8006",
+  user: "root@pam",
+  tokenId: "test-token",
+  tokenSecret: "12345678-1234-1234-1234-123456789abc",
+};
+
+// Helper to create mock response
+function mockResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify({ data }), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("ProxmoxClient", () => {
+  let originalFetch: typeof global.fetch;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  describe("constructor", () => {
+    test("builds correct auth header", () => {
+      const client = new ProxmoxClient(mockConfig);
+      // We can't directly access private fields, but we can test via requests
+      expect(client).toBeDefined();
+    });
+
+    test("strips trailing slash from host", () => {
+      const configWithSlash: ProxmuxConfig = {
+        ...mockConfig,
+        host: "https://proxmox.example.com:8006/",
+      };
+      const client = new ProxmoxClient(configWithSlash);
+      expect(client).toBeDefined();
+    });
+  });
+
+  describe("testConnection", () => {
+    test("returns true on successful connection", async () => {
+      global.fetch = mock(() => Promise.resolve(mockResponse({ version: "7.0" })));
+
+      const client = new ProxmoxClient(mockConfig);
+      const result = await client.testConnection();
+
+      expect(result).toBe(true);
+      expect(global.fetch).toHaveBeenCalled();
+    });
+
+    test("returns false on failed connection", async () => {
+      global.fetch = mock(() => Promise.reject(new Error("Network error")));
+
+      const client = new ProxmoxClient(mockConfig);
+      const result = await client.testConnection();
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("getNodes", () => {
+    test("returns list of nodes", async () => {
+      const mockNodes = [
+        { node: "pve1", status: "online", cpu: 0.5 },
+        { node: "pve2", status: "online", cpu: 0.3 },
+      ];
+      global.fetch = mock(() => Promise.resolve(mockResponse(mockNodes)));
+
+      const client = new ProxmoxClient(mockConfig);
+      const nodes = await client.getNodes();
+
+      expect(nodes).toEqual(mockNodes);
+    });
+
+    test("makes request to correct endpoint", async () => {
+      global.fetch = mock(() => Promise.resolve(mockResponse([])));
+
+      const client = new ProxmoxClient(mockConfig);
+      await client.getNodes();
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://proxmox.example.com:8006/api2/json/nodes",
+        expect.objectContaining({
+          method: "GET",
+          headers: expect.objectContaining({
+            Authorization: "PVEAPIToken=root@pam!test-token=12345678-1234-1234-1234-123456789abc",
+          }),
+        })
+      );
+    });
+  });
+
+  describe("getVMs", () => {
+    test("returns VMs from specific node", async () => {
+      const mockVMs = [
+        { vmid: 100, name: "vm1", status: "running" },
+        { vmid: 101, name: "vm2", status: "stopped" },
+      ];
+      global.fetch = mock(() => Promise.resolve(mockResponse(mockVMs)));
+
+      const client = new ProxmoxClient(mockConfig);
+      const vms = await client.getVMs("pve1");
+
+      expect(vms).toEqual(mockVMs);
+    });
+
+    test("returns VMs from all nodes when no node specified", async () => {
+      const mockNodes = [{ node: "pve1" }, { node: "pve2" }];
+      const mockVMs1 = [{ vmid: 100, name: "vm1" }];
+      const mockVMs2 = [{ vmid: 101, name: "vm2" }];
+
+      let callCount = 0;
+      global.fetch = mock(() => {
+        callCount++;
+        if (callCount === 1) return Promise.resolve(mockResponse(mockNodes));
+        if (callCount === 2) return Promise.resolve(mockResponse(mockVMs1));
+        return Promise.resolve(mockResponse(mockVMs2));
+      });
+
+      const client = new ProxmoxClient(mockConfig);
+      const vms = await client.getVMs();
+
+      expect(vms).toHaveLength(2);
+      expect(vms[0]).toMatchObject({ vmid: 100, node: "pve1" });
+      expect(vms[1]).toMatchObject({ vmid: 101, node: "pve2" });
+    });
+  });
+
+  describe("getContainers", () => {
+    test("returns containers from specific node", async () => {
+      const mockContainers = [
+        { vmid: 200, name: "ct1", status: "running" },
+        { vmid: 201, name: "ct2", status: "stopped" },
+      ];
+      global.fetch = mock(() => Promise.resolve(mockResponse(mockContainers)));
+
+      const client = new ProxmoxClient(mockConfig);
+      const containers = await client.getContainers("pve1");
+
+      expect(containers).toEqual(mockContainers);
+    });
+  });
+
+  describe("VM actions", () => {
+    test("startVM sends POST to correct endpoint", async () => {
+      global.fetch = mock(() => Promise.resolve(mockResponse("UPID:...")));
+
+      const client = new ProxmoxClient(mockConfig);
+      await client.startVM("pve1", 100);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://proxmox.example.com:8006/api2/json/nodes/pve1/qemu/100/status/start",
+        expect.objectContaining({ method: "POST" })
+      );
+    });
+
+    test("stopVM sends POST to correct endpoint", async () => {
+      global.fetch = mock(() => Promise.resolve(mockResponse("UPID:...")));
+
+      const client = new ProxmoxClient(mockConfig);
+      await client.stopVM("pve1", 100);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://proxmox.example.com:8006/api2/json/nodes/pve1/qemu/100/status/stop",
+        expect.objectContaining({ method: "POST" })
+      );
+    });
+
+    test("rebootVM sends POST to correct endpoint", async () => {
+      global.fetch = mock(() => Promise.resolve(mockResponse("UPID:...")));
+
+      const client = new ProxmoxClient(mockConfig);
+      await client.rebootVM("pve1", 100);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://proxmox.example.com:8006/api2/json/nodes/pve1/qemu/100/status/reboot",
+        expect.objectContaining({ method: "POST" })
+      );
+    });
+  });
+
+  describe("Container actions", () => {
+    test("startContainer sends POST to correct endpoint", async () => {
+      global.fetch = mock(() => Promise.resolve(mockResponse("UPID:...")));
+
+      const client = new ProxmoxClient(mockConfig);
+      await client.startContainer("pve1", 200);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://proxmox.example.com:8006/api2/json/nodes/pve1/lxc/200/status/start",
+        expect.objectContaining({ method: "POST" })
+      );
+    });
+
+    test("stopContainer sends POST to correct endpoint", async () => {
+      global.fetch = mock(() => Promise.resolve(mockResponse("UPID:...")));
+
+      const client = new ProxmoxClient(mockConfig);
+      await client.stopContainer("pve1", 200);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://proxmox.example.com:8006/api2/json/nodes/pve1/lxc/200/status/stop",
+        expect.objectContaining({ method: "POST" })
+      );
+    });
+  });
+
+  describe("error handling", () => {
+    test("throws descriptive error on 401", async () => {
+      global.fetch = mock(() =>
+        Promise.resolve(new Response("Unauthorized", { status: 401 }))
+      );
+
+      const client = new ProxmoxClient(mockConfig);
+
+      await expect(client.getNodes()).rejects.toThrow("Authentication failed");
+    });
+
+    test("throws error on 501", async () => {
+      global.fetch = mock(() =>
+        Promise.resolve(new Response("Not Implemented", { status: 501 }))
+      );
+
+      const client = new ProxmoxClient(mockConfig);
+
+      await expect(client.getNodes()).rejects.toThrow("Operation not supported");
+    });
+
+    test("throws generic error on other failures", async () => {
+      global.fetch = mock(() =>
+        Promise.resolve(new Response("Server Error", { status: 500 }))
+      );
+
+      const client = new ProxmoxClient(mockConfig);
+
+      await expect(client.getNodes()).rejects.toThrow("Proxmox API error: 500");
+    });
+  });
+
+  describe("getStorage", () => {
+    test("deduplicates shared storage", async () => {
+      const mockNodes = [{ node: "pve1" }, { node: "pve2" }];
+      const mockStorage1 = [
+        { storage: "local", type: "dir" },
+        { storage: "shared-nfs", type: "nfs" },
+      ];
+      const mockStorage2 = [
+        { storage: "local", type: "dir" },
+        { storage: "shared-nfs", type: "nfs" },
+      ];
+
+      let callCount = 0;
+      global.fetch = mock(() => {
+        callCount++;
+        if (callCount === 1) return Promise.resolve(mockResponse(mockNodes));
+        if (callCount === 2) return Promise.resolve(mockResponse(mockStorage1));
+        return Promise.resolve(mockResponse(mockStorage2));
+      });
+
+      const client = new ProxmoxClient(mockConfig);
+      const storage = await client.getStorage();
+
+      // Should deduplicate - only 2 unique storages
+      expect(storage).toHaveLength(2);
+      expect(storage.map((s) => s.storage)).toEqual(["local", "shared-nfs"]);
+    });
+  });
+});

--- a/tests/components/Select.test.tsx
+++ b/tests/components/Select.test.tsx
@@ -1,0 +1,155 @@
+import React from "react";
+import { describe, expect, test } from "bun:test";
+import { render } from "ink-testing-library";
+import { Select, type SelectOption } from "../../src/components/forms/Select";
+
+const mockOptions: SelectOption<string>[] = [
+  { label: "Option 1", value: "opt1" },
+  { label: "Option 2", value: "opt2", description: "Second option" },
+  { label: "Option 3", value: "opt3" },
+];
+
+describe("Select", () => {
+  describe("rendering", () => {
+    test("renders label and placeholder when no value", () => {
+      const { lastFrame } = render(
+        <Select
+          label="Test Select"
+          options={mockOptions}
+          value={null}
+          onChange={() => {}}
+        />
+      );
+
+      expect(lastFrame()).toContain("Test Select:");
+      expect(lastFrame()).toContain("Select an option...");
+    });
+
+    test("renders selected value", () => {
+      const { lastFrame } = render(
+        <Select
+          label="Test Select"
+          options={mockOptions}
+          value="opt2"
+          onChange={() => {}}
+        />
+      );
+
+      expect(lastFrame()).toContain("Option 2");
+    });
+
+    test("renders custom placeholder", () => {
+      const { lastFrame } = render(
+        <Select
+          label="Test Select"
+          options={mockOptions}
+          value={null}
+          onChange={() => {}}
+          placeholder="Pick one..."
+        />
+      );
+
+      expect(lastFrame()).toContain("Pick one...");
+    });
+
+    test("shows hint when active", () => {
+      const { lastFrame } = render(
+        <Select
+          label="Test Select"
+          options={mockOptions}
+          value={null}
+          onChange={() => {}}
+          isActive={true}
+        />
+      );
+
+      expect(lastFrame()).toContain("↵ to open");
+    });
+
+    test("does not show hint when inactive", () => {
+      const { lastFrame } = render(
+        <Select
+          label="Test Select"
+          options={mockOptions}
+          value={null}
+          onChange={() => {}}
+          isActive={false}
+        />
+      );
+
+      expect(lastFrame()).not.toContain("[Enter to");
+    });
+
+    test("renders with different generic types", () => {
+      const numericOptions: SelectOption<number>[] = [
+        { label: "One", value: 1 },
+        { label: "Two", value: 2 },
+      ];
+
+      const { lastFrame } = render(
+        <Select<number>
+          label="Number"
+          options={numericOptions}
+          value={1}
+          onChange={() => {}}
+        />
+      );
+
+      expect(lastFrame()).toContain("One");
+    });
+
+    test("handles empty options array", () => {
+      const { lastFrame } = render(
+        <Select
+          label="Empty"
+          options={[]}
+          value={null}
+          onChange={() => {}}
+        />
+      );
+
+      expect(lastFrame()).toContain("Empty:");
+      expect(lastFrame()).toContain("Select an option...");
+    });
+  });
+
+  describe("visual states", () => {
+    test("applies active styling when active", () => {
+      const { lastFrame } = render(
+        <Select
+          label="Test"
+          options={mockOptions}
+          value={null}
+          onChange={() => {}}
+          isActive={true}
+        />
+      );
+
+      // Active state shows brackets and hint
+      expect(lastFrame()).toContain("[");
+      expect(lastFrame()).toContain("]");
+      expect(lastFrame()).toContain("↵ to open");
+    });
+
+    test("shows selected value label correctly", () => {
+      const { lastFrame } = render(
+        <Select
+          label="Status"
+          options={[
+            { label: "Active", value: "active" },
+            { label: "Inactive", value: "inactive" },
+          ]}
+          value="active"
+          onChange={() => {}}
+        />
+      );
+
+      expect(lastFrame()).toContain("Active");
+      expect(lastFrame()).not.toContain("Inactive");
+    });
+  });
+
+  // Note: Keyboard interaction tests require a different testing approach
+  // since useInput hooks don't work the same way in the test environment.
+  // These would be better suited for integration/e2e tests.
+});

--- a/tests/components/TextInput.test.tsx
+++ b/tests/components/TextInput.test.tsx
@@ -1,0 +1,210 @@
+import React from "react";
+import { describe, expect, test } from "bun:test";
+import { render } from "ink-testing-library";
+import { TextInput } from "../../src/components/forms/TextInput";
+
+describe("TextInput", () => {
+  describe("rendering", () => {
+    test("renders label and value", () => {
+      const { lastFrame } = render(
+        <TextInput
+          label="Username"
+          value="john"
+          onChange={() => {}}
+        />
+      );
+
+      expect(lastFrame()).toContain("Username:");
+      expect(lastFrame()).toContain("john");
+    });
+
+    test("renders placeholder when empty", () => {
+      const { lastFrame } = render(
+        <TextInput
+          label="Username"
+          value=""
+          onChange={() => {}}
+          placeholder="Enter username..."
+        />
+      );
+
+      expect(lastFrame()).toContain("Enter username...");
+    });
+
+    test("shows cursor when active", () => {
+      const { lastFrame } = render(
+        <TextInput
+          label="Username"
+          value="test"
+          onChange={() => {}}
+          isActive={true}
+        />
+      );
+
+      // Should show cursor block character
+      expect(lastFrame()).toContain("█");
+    });
+
+    test("does not show cursor when inactive", () => {
+      const { lastFrame } = render(
+        <TextInput
+          label="Username"
+          value="test"
+          onChange={() => {}}
+          isActive={false}
+        />
+      );
+
+      expect(lastFrame()).not.toContain("█");
+    });
+
+    test("masks password input", () => {
+      const { lastFrame } = render(
+        <TextInput
+          label="Password"
+          value="secret"
+          onChange={() => {}}
+          password={true}
+        />
+      );
+
+      expect(lastFrame()).not.toContain("secret");
+      expect(lastFrame()).toContain("••••••");
+    });
+
+    test("shows masked password with cursor when active", () => {
+      const { lastFrame } = render(
+        <TextInput
+          label="Password"
+          value="abc"
+          onChange={() => {}}
+          password={true}
+          isActive={true}
+        />
+      );
+
+      expect(lastFrame()).not.toContain("abc");
+      expect(lastFrame()).toContain("•••");
+      expect(lastFrame()).toContain("█");
+    });
+  });
+
+  describe("visual states", () => {
+    test("applies active styling when active", () => {
+      const { lastFrame } = render(
+        <TextInput
+          label="Test"
+          value=""
+          onChange={() => {}}
+          isActive={true}
+        />
+      );
+
+      // Active state shows brackets with cursor
+      expect(lastFrame()).toContain("[");
+      expect(lastFrame()).toContain("]");
+      expect(lastFrame()).toContain("█"); // cursor
+    });
+
+    test("respects width prop", () => {
+      const { lastFrame } = render(
+        <TextInput
+          label="Description"
+          value="Short"
+          onChange={() => {}}
+          width={20}
+        />
+      );
+
+      // Component should render without error
+      expect(lastFrame()).toContain("Description:");
+      expect(lastFrame()).toContain("Short");
+    });
+
+    test("handles long values", () => {
+      const longValue = "This is a very long text that exceeds the default width";
+      const { lastFrame } = render(
+        <TextInput
+          label="Long"
+          value={longValue}
+          onChange={() => {}}
+          width={30}
+        />
+      );
+
+      // Should truncate to fit within width
+      const frame = lastFrame();
+      expect(frame).toContain("Long:");
+      expect(frame).toBeDefined();
+    });
+  });
+
+  describe("placeholder behavior", () => {
+    test("shows placeholder when value is empty", () => {
+      const { lastFrame } = render(
+        <TextInput
+          label="Name"
+          value=""
+          onChange={() => {}}
+          placeholder="Enter name"
+        />
+      );
+
+      expect(lastFrame()).toContain("Enter name");
+    });
+
+    test("does not show placeholder when value exists", () => {
+      const { lastFrame } = render(
+        <TextInput
+          label="Name"
+          value="John"
+          onChange={() => {}}
+          placeholder="Enter name"
+        />
+      );
+
+      expect(lastFrame()).toContain("John");
+      expect(lastFrame()).not.toContain("Enter name");
+    });
+  });
+
+  describe("required indicator", () => {
+    test("required prop is accepted", () => {
+      const { lastFrame } = render(
+        <TextInput
+          label="Email"
+          value="test@example.com"
+          onChange={() => {}}
+          required={true}
+        />
+      );
+
+      // Component renders correctly with required prop
+      expect(lastFrame()).toContain("Email:");
+    });
+  });
+
+  describe("validator prop", () => {
+    test("accepts validator function", () => {
+      const emailValidator = (v: string) =>
+        v.includes("@") ? null : "Invalid email";
+
+      const { lastFrame } = render(
+        <TextInput
+          label="Email"
+          value="test@example.com"
+          onChange={() => {}}
+          validator={emailValidator}
+        />
+      );
+
+      // Component renders correctly with validator
+      expect(lastFrame()).toContain("Email:");
+    });
+  });
+
+  // Note: Keyboard interaction and validation error display tests
+  // require a different testing approach since useInput hooks and
+  // useEffect don't work the same way in the test environment.
+  // These would be better suited for integration/e2e tests.
+});

--- a/tests/utils/format.test.ts
+++ b/tests/utils/format.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test } from "bun:test";
+import {
+  formatBytes,
+  formatPercent,
+  formatUptime,
+  formatCPU,
+  formatMemory,
+  truncate,
+  padRight,
+  padLeft,
+} from "../../src/utils/format";
+
+describe("formatBytes", () => {
+  test("formats 0 bytes", () => {
+    expect(formatBytes(0)).toBe("0 B");
+  });
+
+  test("formats bytes", () => {
+    expect(formatBytes(500)).toBe("500.0 B");
+  });
+
+  test("formats kilobytes", () => {
+    expect(formatBytes(1024)).toBe("1.0 KB");
+    expect(formatBytes(1536)).toBe("1.5 KB");
+  });
+
+  test("formats megabytes", () => {
+    expect(formatBytes(1048576)).toBe("1.0 MB");
+    expect(formatBytes(1572864)).toBe("1.5 MB");
+  });
+
+  test("formats gigabytes", () => {
+    expect(formatBytes(1073741824)).toBe("1.0 GB");
+    expect(formatBytes(5368709120)).toBe("5.0 GB");
+  });
+
+  test("formats terabytes", () => {
+    expect(formatBytes(1099511627776)).toBe("1.0 TB");
+  });
+});
+
+describe("formatPercent", () => {
+  test("formats decimal as percentage", () => {
+    expect(formatPercent(0.5)).toBe("50.0%");
+    expect(formatPercent(1)).toBe("100.0%");
+    expect(formatPercent(0)).toBe("0.0%");
+  });
+
+  test("respects decimal precision", () => {
+    expect(formatPercent(0.1234, 2)).toBe("12.34%");
+    expect(formatPercent(0.1234, 0)).toBe("12%");
+  });
+});
+
+describe("formatUptime", () => {
+  test("formats minutes only", () => {
+    expect(formatUptime(60)).toBe("1m");
+    expect(formatUptime(300)).toBe("5m");
+  });
+
+  test("formats hours and minutes", () => {
+    expect(formatUptime(3660)).toBe("1h 1m");
+    expect(formatUptime(7200)).toBe("2h");
+  });
+
+  test("formats days, hours, and minutes", () => {
+    expect(formatUptime(90061)).toBe("1d 1h 1m");
+    expect(formatUptime(86400)).toBe("1d");
+  });
+
+  test("handles zero seconds", () => {
+    expect(formatUptime(0)).toBe("0m");
+  });
+
+  test("handles large uptimes", () => {
+    // 30 days
+    expect(formatUptime(2592000)).toBe("30d");
+  });
+});
+
+describe("formatCPU", () => {
+  test("formats CPU usage as percentage with core count", () => {
+    expect(formatCPU(0.5, 4)).toBe("12.5% (4 cores)");
+    expect(formatCPU(2, 4)).toBe("50.0% (4 cores)");
+  });
+
+  test("handles zero cores", () => {
+    expect(formatCPU(1, 0)).toBe("0.0% (0 cores)");
+  });
+});
+
+describe("formatMemory", () => {
+  test("formats memory usage with percentage", () => {
+    const result = formatMemory(536870912, 1073741824); // 512MB / 1GB
+    expect(result).toBe("512.0 MB / 1.0 GB (50.0%)");
+  });
+
+  test("handles zero max memory", () => {
+    const result = formatMemory(0, 0);
+    expect(result).toBe("0 B / 0 B (0.0%)");
+  });
+});
+
+describe("truncate", () => {
+  test("returns original string if shorter than length", () => {
+    expect(truncate("hello", 10)).toBe("hello");
+  });
+
+  test("truncates long strings with ellipsis", () => {
+    expect(truncate("hello world", 8)).toBe("hello w…");
+  });
+
+  test("handles exact length", () => {
+    expect(truncate("hello", 5)).toBe("hello");
+  });
+
+  test("handles length of 1", () => {
+    expect(truncate("hello", 1)).toBe("…");
+  });
+});
+
+describe("padRight", () => {
+  test("pads string to specified length", () => {
+    expect(padRight("hi", 5)).toBe("hi   ");
+  });
+
+  test("returns original if already long enough", () => {
+    expect(padRight("hello", 3)).toBe("hello");
+  });
+});
+
+describe("padLeft", () => {
+  test("pads string to specified length", () => {
+    expect(padLeft("hi", 5)).toBe("   hi");
+  });
+
+  test("returns original if already long enough", () => {
+    expect(padLeft("hello", 3)).toBe("hello");
+  });
+});


### PR DESCRIPTION
## Summary
This PR adds creation wizards for both VMs and LXC containers, along with a comprehensive test suite.

## Features

### LXC Container Creation Wizard
- Multi-step wizard accessible via `c` key in Containers view
- **Basic Config**: Node selection, CT ID, hostname
- **Templates**: Local template selection or download from Proxmox repository
- **Authentication**: Root password and optional SSH key
- **Resources**: CPU cores, memory, swap
- **Storage**: Root disk storage and size
- **Network**: Bridge selection, DHCP or static IP configuration
- **Options**: Unprivileged mode, start on boot, nesting

### VM Creation Wizard  
- Multi-step wizard accessible via `c` key in VMs view
- **Basic Config**: Node selection, VM ID, name
- **OS Selection**: ISO image selection from available storage
- **Resources**: CPU cores, sockets, memory
- **Storage**: Disk storage, size, and format
- **Network**: Bridge selection, network model

### Shared Improvements
- Reusable wizard framework and form components
- Type-to-search filtering in Select dropdowns (handles 100+ templates)
- Keyboard shortcut fixes: no conflicts with form input (numbers, special chars)
- Help overlay (`?`) with keyboard shortcuts reference
- Status bar hints for available actions

### Test Suite
- 65 passing tests using bun:test and ink-testing-library
- Unit tests for utilities (formatBytes, formatUptime, etc.)
- API client tests with mocking (auth, requests, error handling)
- Component tests for Select and TextInput

## Screenshots
(The UI is terminal-based - run `./dist/proxmux` to see)

## Test Plan
- [x] All 65 tests pass
- [x] Build succeeds
- [ ] Manual testing of LXC creation with DHCP/static IP
- [ ] Manual testing of VM creation
- [ ] Template download functionality

## Breaking Changes
None - this is additive functionality.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)